### PR TITLE
Add static SEO and Open Graph meta tags to index.html

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,6 +1,7 @@
 # Palette Persona Learnings
 
 ## Metadata and SEO
+
 - **Learning**: Single Page Applications (SPAs) using client-side head management (like `@unhead/react`) may fail metadata checks by crawlers that do not execute JavaScript.
 - **Action**: Always provide static fallback meta tags in `index.html` for critical SEO and social sharing (Open Graph, Twitter) to ensure accessibility and discoverability by all bots.
 - **Verification**: Use both build artifact inspection (`dist/index.html`) and runtime verification (Playwright) to ensure tags are present statically and managed correctly dynamically.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+# Palette Persona Learnings
+
+## Metadata and SEO
+- **Learning**: Single Page Applications (SPAs) using client-side head management (like `@unhead/react`) may fail metadata checks by crawlers that do not execute JavaScript.
+- **Action**: Always provide static fallback meta tags in `index.html` for critical SEO and social sharing (Open Graph, Twitter) to ensure accessibility and discoverability by all bots.
+- **Verification**: Use both build artifact inspection (`dist/index.html`) and runtime verification (Playwright) to ensure tags are present statically and managed correctly dynamically.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Long Nhat Nguyen | Website</title>
+    <meta name="description" content="Welcome to Long Nhat Nguyen's website." />
+    <meta property="og:title" content="Long Nhat Nguyen | Website" />
+    <meta property="og:description" content="Welcome to Long Nhat Nguyen's website." />
+    <meta property="og:image" content="https://torn4dom4n.github.io/og-image.jpg" />
+    <meta property="og:url" content="https://torn4dom4n.github.io" />
+    <meta name="twitter:card" content="summary_large_image" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Added static fallback meta tags for title, description, and Open Graph to `index.html`. This ensures that crawlers that do not execute JavaScript (like some social media bots and search engines) can still find the site's metadata. The values match those dynamically managed by `@unhead/react` in `src/components/site-head.tsx`.

---
*PR created automatically by Jules for task [12826579443435642659](https://jules.google.com/task/12826579443435642659) started by @torn4dom4n*