### PR TITLE
refactor: rename "Let's connect" to "Get in touch"

### DIFF
--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -16,12 +16,12 @@ type Brand = {
   logo: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 };
 
-export default function LetsConnect() {
+export default function GetInTouch() {
   return (
     <div className="relative max-w-full">
       <GridContainer>
         <h2 className="max-w-lg px-2 text-[2.5rem]/10 font-medium tracking-tighter text-balance max-sm:px-4 2xl:mt-0">
-          Let's connect.
+          Get in touch.
         </h2>
       </GridContainer>
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,5 @@
+import GetInTouch from "@/components/get-in-touch";
 import Hero from "@/components/hero";
-import LetsConnect from "@/components/lets-connect";
 import NowPlaying from "@/components/now-playing";
 import { Footer } from "@/components/site-footer";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -20,7 +20,7 @@ function Home() {
 
             <div className="grid gap-24 pb-24 text-gray-950 sm:gap-40 md:pb-40 dark:text-white">
               <Hero />
-              <LetsConnect />
+              <GetInTouch />
               <NowPlaying />
             </div>
 


### PR DESCRIPTION
This PR renames the "Let's connect" section to "Get in touch" to better align with the desired tone.

Changes:
- Renamed `src/components/lets-connect.tsx` to `src/components/get-in-touch.tsx`.
- Updated the component function name from `LetsConnect` to `GetInTouch`.
- Updated the heading text in the component to "Get in touch.".
- Updated the import and usage in `src/pages/home.tsx`.

Verified the changes with `pnpm run check` and visual inspection via Playwright.

---
*PR created automatically by Jules for task [8631504932245130223](https://jules.google.com/task/8631504932245130223) started by @torn4dom4n*