### PR TITLE
Remove "[Running...]" and striped background patterns

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -16,7 +16,7 @@ function App() {
       <main id="main-content" className="isolate">
         <div className="max-w-screen overflow-x-hidden">
           <div className="grid min-h-dvh grid-cols-1 grid-rows-[1fr_auto] justify-center [--gutter-width:2.5rem] md:-mx-4 md:grid-cols-[var(--gutter-width)_minmax(0,var(--breakpoint-2xl))_var(--gutter-width)] lg:mx-0">
-            <div className="relative z-10 col-start-1 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:block dark:[--pattern-fg:var(--color-white)]/10" />
+            <div className="relative z-10 col-start-1 row-span-full row-start-1 hidden border-x border-gray-950/5 md:block dark:border-white/10" />
 
             <div className="grid gap-24 pb-24 text-gray-950 sm:gap-40 md:pb-40 dark:text-white">
               <Hero />
@@ -24,7 +24,7 @@ function App() {
               <GetInTouch />
             </div>
 
-            <div className="relative z-10 row-span-full row-start-1 hidden border-x border-x-(--pattern-fg) bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 md:col-start-3 md:block dark:[--pattern-fg:var(--color-white)]/10" />
+            <div className="relative z-10 row-span-full row-start-1 hidden border-x border-gray-950/5 md:col-start-3 md:block dark:border-white/10" />
 
             <div className="md:col-start-2">
               <Footer className="px-4 md:px-6 lg:px-8" />

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -25,10 +25,7 @@ export default function GetInTouch() {
         </h2>
       </GridContainer>
 
-      <div
-        aria-hidden="true"
-        className="h-6 bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:h-10 dark:[--pattern-fg:var(--color-white)]/10"
-      />
+      <div className="h-6 sm:h-10" />
 
       <GridContainer>
         <p className="max-w-(--breakpoint-md) px-2 text-base/7 text-gray-600 max-sm:px-4 dark:text-gray-400">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -2,24 +2,14 @@ import GridContainer from "@/components/ui/grid-container";
 
 export default function Hero() {
   return (
-    <div>
-      <div
-        aria-hidden="true"
-        className="flex h-16 items-end px-2 font-mono text-xs/6 whitespace-pre text-black/20 max-sm:px-4 sm:h-24 dark:text-white/25"
-      >
-        <span className="inline">[Running...]</span>
-      </div>
-
+    <div className="pt-16 sm:pt-24">
       <GridContainer>
         <h1 className="px-2 text-4xl tracking-tighter text-balance max-lg:font-medium max-sm:px-4 sm:text-5xl lg:text-6xl xl:text-8xl">
           What's up everybody.
         </h1>
       </GridContainer>
 
-      <div
-        aria-hidden="true"
-        className="h-6 bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:h-10 dark:[--pattern-fg:var(--color-white)]/10"
-      />
+      <div className="h-6 sm:h-10" />
 
       <GridContainer>
         <p className="max-w-(--breakpoint-md) px-2 text-lg/7 font-medium text-gray-600 max-sm:px-4 dark:text-gray-400">

--- a/src/components/now-playing.tsx
+++ b/src/components/now-playing.tsx
@@ -18,10 +18,7 @@ export default function NowPlaying() {
         </h2>
       </GridContainer>
 
-      <div
-        aria-hidden="true"
-        className="h-6 bg-[repeating-linear-gradient(315deg,var(--pattern-fg)_0,var(--pattern-fg)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px] bg-fixed [--pattern-fg:var(--color-black)]/5 sm:h-10 dark:[--pattern-fg:var(--color-white)]/10"
-      />
+      <div className="h-6 sm:h-10" />
 
       <GridContainer>
         <p className="max-w-(--breakpoint-md) px-2 text-base/7 text-gray-600 max-sm:px-4 dark:text-gray-400">


### PR DESCRIPTION
This change removes the "[Running...]" placeholder text from the Hero section and replaces all instances of the striped background pattern (repeating-linear-gradient) with simple spacers or solid borders. This aligns the site with a more minimalist aesthetic.

Key changes:
- src/components/hero.tsx: Removed "[Running...]" and striped divider.
- src/components/now-playing.tsx: Removed striped divider.
- src/components/get-in-touch.tsx: Removed striped divider.
- src/app/app.tsx: Replaced striped side gutters with solid borders.
- Verified linting, formatting, and types with vp check.
- Visually verified changes via Playwright screenshots.

---
*PR created automatically by Jules for task [11774887530981219244](https://jules.google.com/task/11774887530981219244) started by @torn4dom4n*