### PR TITLE
Implement Martin Garrix style marquee for Socials

### DIFF
--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import FacebookIcon from "~icons/simple-icons/facebook";
 import GitHubIcon from "~icons/simple-icons/github";
 import InstagramIcon from "~icons/simple-icons/instagram";
@@ -5,11 +6,14 @@ import LinkedInIcon from "~icons/simple-icons/linkedin";
 import PinterestIcon from "~icons/simple-icons/pinterest";
 import RedditIcon from "~icons/simple-icons/reddit";
 import SoundCloudIcon from "~icons/simple-icons/soundcloud";
+import SpotifyIcon from "~icons/simple-icons/spotify";
+import TikTokIcon from "~icons/simple-icons/tiktok";
 import XIcon from "~icons/simple-icons/x";
 import YouTubeIcon from "~icons/simple-icons/youtube";
 
 import GridContainer from "@/components/ui/grid-container";
 import SectionHeader from "@/components/ui/section-header";
+import { cn } from "@/lib/utils";
 
 type Brand = {
   name: string;
@@ -18,6 +22,27 @@ type Brand = {
 };
 
 export default function GetInTouch() {
+  const [isVisible, setIsVisible] = useState(false);
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.unobserve(entry.target);
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    if (sectionRef.current) {
+      observer.observe(sectionRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="relative max-w-full">
       <GridContainer className="2xl:before:hidden 2xl:after:hidden">
@@ -39,42 +64,28 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section
-        className="mt-16 overflow-hidden border-y border-border py-12"
-        aria-label="Social media links"
-      >
-        {/* Accessible non-animated list for screen readers */}
-        <ul className="sr-only">
-          {brands.map(({ name, url }) => (
-            <li key={name}>
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                {name} (opens in a new tab)
+      <section ref={sectionRef} className="mt-16 flex justify-center px-4" aria-label="Follow Me">
+        <div className="grid grid-cols-2 border-t border-l border-border sm:grid-cols-4 lg:grid-cols-5">
+          {brands.map(({ name, url, logo: Logo }, index) => (
+            <div
+              key={name}
+              className={cn(
+                "social-grid-item border-r border-b border-border",
+                isVisible && "is-visible",
+              )}
+              style={{ "--delay": `${index * 50}ms` } as React.CSSProperties}
+            >
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex aspect-square size-full min-h-24 min-w-24 items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:size-32"
+                aria-label={`Follow me on ${name} (opens in a new tab)`}
+              >
+                <Logo className="size-8 sm:size-10" />
               </a>
-            </li>
+            </div>
           ))}
-        </ul>
-
-        {/* Visual marquee track */}
-        <div className="group flex overflow-hidden" aria-hidden="true">
-          <div className="flex animate-marquee py-4 whitespace-nowrap group-hover:[animation-play-state:paused]">
-            {[...brands, ...brands].map(({ name, url, logo: Logo }, index) => (
-              <div key={`${name}-${index}`} className="flex items-center">
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-4 px-8 transition-colors hover:text-ring sm:px-12"
-                  tabIndex={-1}
-                >
-                  <Logo className="size-8 sm:size-12" />
-                  <span className="text-3xl font-bold tracking-tighter uppercase sm:text-5xl">
-                    {name}
-                  </span>
-                </a>
-                <span className="text-2xl text-border sm:text-4xl">✦</span>
-              </div>
-            ))}
-          </div>
         </div>
       </section>
     </div>
@@ -82,21 +93,6 @@ export default function GetInTouch() {
 }
 
 const brands: Brand[] = [
-  {
-    name: "GitHub",
-    url: "https://github.com/torn4dom4n",
-    logo: GitHubIcon,
-  },
-  {
-    name: "X",
-    url: "https://x.com/torn4dom4n",
-    logo: XIcon,
-  },
-  {
-    name: "Facebook",
-    url: "https://facebook.com/torn4dom4n",
-    logo: FacebookIcon,
-  },
   {
     name: "Instagram",
     url: "https://instagram.com/torn4dom4n",
@@ -106,6 +102,31 @@ const brands: Brand[] = [
     name: "YouTube",
     url: "https://youtube.com/@torn4dom4n",
     logo: YouTubeIcon,
+  },
+  {
+    name: "Spotify",
+    url: "https://open.spotify.com/user/torn4dom4n",
+    logo: SpotifyIcon,
+  },
+  {
+    name: "Facebook",
+    url: "https://facebook.com/torn4dom4n",
+    logo: FacebookIcon,
+  },
+  {
+    name: "TikTok",
+    url: "https://tiktok.com/@torn4dom4n",
+    logo: TikTokIcon,
+  },
+  {
+    name: "X",
+    url: "https://x.com/torn4dom4n",
+    logo: XIcon,
+  },
+  {
+    name: "GitHub",
+    url: "https://github.com/torn4dom4n",
+    logo: GitHubIcon,
   },
   {
     name: "LinkedIn",

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -42,21 +42,37 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section className="mt-16 flex justify-center px-4" aria-label="Follow Me">
-        <div className="grid grid-cols-4 border-t border-l border-border sm:grid-cols-5 md:grid-cols-6">
-          {brands.map(({ name, url, logo: Logo }) => (
-            <div key={name} className="border-r border-b border-border">
-              <a
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex aspect-square size-full min-h-20 min-w-20 items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:size-32"
-                aria-label={`Follow me on ${name} (opens in a new tab)`}
+      <section>
+        <div className="relative isolate mt-16">
+          {/* Vertical dividers overlay */}
+          <div className="pointer-events-none absolute inset-0 z-10 grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
+            <div className="border-r border-border" />
+            <div className="border-r border-border" />
+            <div className="border-r border-border" />
+            <div className="border-r border-border max-md:hidden" />
+            <div className="border-r border-border max-md:hidden" />
+            <div className="border-r border-border max-lg:hidden" />
+            <div className="border-r border-border max-lg:hidden" />
+          </div>
+
+          <ul className="grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
+            {brands.map(({ name, url, logo: Logo }) => (
+              <li
+                key={name}
+                className="max-md:nth-[4n+1]:line-y md:max-lg:nth-[6n+1]:line-y lg:nth-[8n+1]:line-y"
               >
-                <Logo className="size-8 sm:size-10" />
-              </a>
-            </div>
-          ))}
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex aspect-square size-full items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
+                  aria-label={`Follow me on ${name} (opens in a new tab)`}
+                >
+                  <Logo className="size-8 sm:size-10" aria-hidden="true" />
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
     </div>

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -62,10 +62,15 @@ export default function GetInTouch() {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
+                  className="group relative flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
                   aria-label={`Follow me on ${name} (opens in a new tab)`}
                 >
-                  <Logo className="size-8 sm:size-10" aria-hidden="true" />
+                  <div className="flex flex-col items-center transition-transform duration-300 group-hover:-translate-y-2 sm:group-hover:-translate-y-3">
+                    <Logo className="size-8 sm:size-10" aria-hidden="true" />
+                    <span className="absolute top-full mt-1 text-[10px] font-bold tracking-widest uppercase opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:mt-2 sm:text-xs">
+                      {name}
+                    </span>
+                  </div>
                 </a>
               </li>
             ))}

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import AppleIcon from "~icons/simple-icons/apple";
 import FacebookIcon from "~icons/simple-icons/facebook";
 import GitHubIcon from "~icons/simple-icons/github";
 import InstagramIcon from "~icons/simple-icons/instagram";
 import LinkedInIcon from "~icons/simple-icons/linkedin";
-import PinterestIcon from "~icons/simple-icons/pinterest";
 import RedditIcon from "~icons/simple-icons/reddit";
+import SnapchatIcon from "~icons/simple-icons/snapchat";
 import SoundCloudIcon from "~icons/simple-icons/soundcloud";
 import SpotifyIcon from "~icons/simple-icons/spotify";
 import TikTokIcon from "~icons/simple-icons/tiktok";
@@ -13,7 +13,6 @@ import YouTubeIcon from "~icons/simple-icons/youtube";
 
 import GridContainer from "@/components/ui/grid-container";
 import SectionHeader from "@/components/ui/section-header";
-import { cn } from "@/lib/utils";
 
 type Brand = {
   name: string;
@@ -22,27 +21,6 @@ type Brand = {
 };
 
 export default function GetInTouch() {
-  const [isVisible, setIsVisible] = useState(false);
-  const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-          observer.unobserve(entry.target);
-        }
-      },
-      { threshold: 0.1 },
-    );
-
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
-
   return (
     <div className="relative max-w-full">
       <GridContainer className="2xl:before:hidden 2xl:after:hidden">
@@ -64,22 +42,15 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section ref={sectionRef} className="mt-16 flex justify-center px-4" aria-label="Follow Me">
-        <div className="grid grid-cols-2 border-t border-l border-border sm:grid-cols-4 lg:grid-cols-5">
-          {brands.map(({ name, url, logo: Logo }, index) => (
-            <div
-              key={name}
-              className={cn(
-                "social-grid-item border-r border-b border-border",
-                isVisible && "is-visible",
-              )}
-              style={{ "--delay": `${index * 50}ms` } as React.CSSProperties}
-            >
+      <section className="mt-16 flex justify-center px-4" aria-label="Follow Me">
+        <div className="grid grid-cols-4 border-t border-l border-border sm:grid-cols-5 md:grid-cols-6">
+          {brands.map(({ name, url, logo: Logo }) => (
+            <div key={name} className="border-r border-b border-border">
               <a
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex aspect-square size-full min-h-24 min-w-24 items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:size-32"
+                className="flex aspect-square size-full min-h-20 min-w-20 items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:size-32"
                 aria-label={`Follow me on ${name} (opens in a new tab)`}
               >
                 <Logo className="size-8 sm:size-10" />
@@ -124,6 +95,16 @@ const brands: Brand[] = [
     logo: XIcon,
   },
   {
+    name: "Snapchat",
+    url: "https://snapchat.com/add/torn4dom4n",
+    logo: SnapchatIcon,
+  },
+  {
+    name: "Apple",
+    url: "https://music.apple.com/profile/torn4dom4n",
+    logo: AppleIcon,
+  },
+  {
     name: "GitHub",
     url: "https://github.com/torn4dom4n",
     logo: GitHubIcon,
@@ -137,11 +118,6 @@ const brands: Brand[] = [
     name: "Reddit",
     url: "https://reddit.com/user/torn4dom4n",
     logo: RedditIcon,
-  },
-  {
-    name: "Pinterest",
-    url: "https://pinterest.com/torn4dom4n",
-    logo: PinterestIcon,
   },
   {
     name: "SoundCloud",

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -42,7 +42,7 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section>
+      <section aria-label="Follow Me">
         <div className="relative isolate mt-16">
           {/* Vertical dividers overlay */}
           <div className="pointer-events-none absolute inset-0 z-10 grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
@@ -65,7 +65,7 @@ export default function GetInTouch() {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex aspect-square size-full items-center justify-center text-foreground transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
+                  className="flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
                   aria-label={`Follow me on ${name} (opens in a new tab)`}
                 >
                   <Logo className="size-8 sm:size-10" aria-hidden="true" />
@@ -73,6 +73,9 @@ export default function GetInTouch() {
               </li>
             ))}
           </ul>
+
+          {/* Bottom line to complete the grid */}
+          <div className="absolute bottom-0 left-1/2 h-px w-[200vw] -translate-x-1/2 bg-border" />
         </div>
       </section>
     </div>

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -39,38 +39,42 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section>
-        <div className="relative isolate mt-16">
-          <div className="pointer-events-none absolute inset-0 z-10 grid grid-cols-2 gap-10 max-md:gap-5 lg:grid-cols-3 xl:grid-cols-4">
-            <div className="border-r border-border" />
-            <div className="border-l border-border lg:border-x" />
-            <div className="border-l border-border max-lg:hidden xl:border-x" />
-            <div className="border-l border-border max-xl:hidden" />
-          </div>
+      <section
+        className="mt-16 overflow-hidden border-y border-border py-12"
+        aria-label="Social media links"
+      >
+        {/* Accessible non-animated list for screen readers */}
+        <ul className="sr-only">
+          {brands.map(({ name, url }) => (
+            <li key={name}>
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                {name} (opens in a new tab)
+              </a>
+            </li>
+          ))}
+        </ul>
 
-          <ul className="grid grid-cols-2 gap-5 md:gap-10 lg:grid-cols-3 xl:grid-cols-4">
-            {brands.map(({ name, url, logo: Logo }) => (
-              <li
-                key={name}
-                className="max-lg:nth-[2n+1]:line-y lg:max-xl:nth-[3n+1]:line-y xl:nth-[4n+1]:line-y"
-              >
+        {/* Visual marquee track */}
+        <div className="group flex overflow-hidden" aria-hidden="true">
+          <div className="flex animate-marquee py-4 whitespace-nowrap group-hover:[animation-play-state:paused]">
+            {[...brands, ...brands].map(({ name, url, logo: Logo }, index) => (
+              <div key={`${name}-${index}`} className="flex items-center">
                 <a
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="grid place-content-center transition-colors hover:bg-accent/50 sm:px-2 sm:py-4"
+                  className="flex items-center gap-4 px-8 transition-colors hover:text-ring sm:px-12"
+                  tabIndex={-1}
                 >
-                  <div className="flex h-24 w-full max-w-80 items-center gap-4">
-                    <Logo className="size-12" aria-hidden="true" />
-                    <span className="text-lg font-medium text-foreground/80">
-                      {name}
-                      <span className="sr-only"> (opens in a new tab)</span>
-                    </span>
-                  </div>
+                  <Logo className="size-8 sm:size-12" />
+                  <span className="text-3xl font-bold tracking-tighter uppercase sm:text-5xl">
+                    {name}
+                  </span>
                 </a>
-              </li>
+                <span className="text-2xl text-border sm:text-4xl">✦</span>
+              </div>
             ))}
-          </ul>
+          </div>
         </div>
       </section>
     </div>

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -1,13 +1,10 @@
-import AppleIcon from "~icons/simple-icons/apple";
 import FacebookIcon from "~icons/simple-icons/facebook";
 import GitHubIcon from "~icons/simple-icons/github";
 import InstagramIcon from "~icons/simple-icons/instagram";
 import LinkedInIcon from "~icons/simple-icons/linkedin";
+import PinterestIcon from "~icons/simple-icons/pinterest";
 import RedditIcon from "~icons/simple-icons/reddit";
-import SnapchatIcon from "~icons/simple-icons/snapchat";
 import SoundCloudIcon from "~icons/simple-icons/soundcloud";
-import SpotifyIcon from "~icons/simple-icons/spotify";
-import TikTokIcon from "~icons/simple-icons/tiktok";
 import XIcon from "~icons/simple-icons/x";
 import YouTubeIcon from "~icons/simple-icons/youtube";
 
@@ -81,6 +78,21 @@ export default function GetInTouch() {
 
 const brands: Brand[] = [
   {
+    name: "GitHub",
+    url: "https://github.com/torn4dom4n",
+    logo: GitHubIcon,
+  },
+  {
+    name: "X",
+    url: "https://x.com/torn4dom4n",
+    logo: XIcon,
+  },
+  {
+    name: "Facebook",
+    url: "https://facebook.com/torn4dom4n",
+    logo: FacebookIcon,
+  },
+  {
     name: "Instagram",
     url: "https://instagram.com/torn4dom4n",
     logo: InstagramIcon,
@@ -91,41 +103,6 @@ const brands: Brand[] = [
     logo: YouTubeIcon,
   },
   {
-    name: "Spotify",
-    url: "https://open.spotify.com/user/torn4dom4n",
-    logo: SpotifyIcon,
-  },
-  {
-    name: "Facebook",
-    url: "https://facebook.com/torn4dom4n",
-    logo: FacebookIcon,
-  },
-  {
-    name: "TikTok",
-    url: "https://tiktok.com/@torn4dom4n",
-    logo: TikTokIcon,
-  },
-  {
-    name: "X",
-    url: "https://x.com/torn4dom4n",
-    logo: XIcon,
-  },
-  {
-    name: "Snapchat",
-    url: "https://snapchat.com/add/torn4dom4n",
-    logo: SnapchatIcon,
-  },
-  {
-    name: "Apple",
-    url: "https://music.apple.com/profile/torn4dom4n",
-    logo: AppleIcon,
-  },
-  {
-    name: "GitHub",
-    url: "https://github.com/torn4dom4n",
-    logo: GitHubIcon,
-  },
-  {
     name: "LinkedIn",
     url: "https://linkedin.com/in/torn4dom4n",
     logo: LinkedInIcon,
@@ -134,6 +111,11 @@ const brands: Brand[] = [
     name: "Reddit",
     url: "https://reddit.com/user/torn4dom4n",
     logo: RedditIcon,
+  },
+  {
+    name: "Pinterest",
+    url: "https://pinterest.com/torn4dom4n",
+    logo: PinterestIcon,
   },
   {
     name: "SoundCloud",

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -59,7 +59,7 @@ export default function GetInTouch() {
             {brands.map(({ name, url, logo: Logo }) => (
               <li
                 key={name}
-                className="max-md:nth-[4n+1]:line-y md:max-lg:nth-[6n+1]:line-y lg:nth-[8n+1]:line-y"
+                className="max-md:nth-[4n+1]:line-y max-md:nth-[4n+5]:before:hidden md:max-lg:nth-[6n+1]:line-y md:max-lg:nth-[6n+7]:before:hidden lg:nth-[8n+1]:line-y lg:nth-[8n+9]:before:hidden"
               >
                 <a
                   href={url}
@@ -73,9 +73,6 @@ export default function GetInTouch() {
               </li>
             ))}
           </ul>
-
-          {/* Bottom line to complete the grid */}
-          <div className="absolute bottom-0 left-1/2 h-px w-[200vw] -translate-x-1/2 bg-border" />
         </div>
       </section>
     </div>

--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -39,9 +39,8 @@ export default function GetInTouch() {
         </p>
       </GridContainer>
 
-      <section aria-label="Follow Me">
+      <section aria-label="Get in Touch">
         <div className="relative isolate mt-16">
-          {/* Vertical dividers overlay */}
           <div className="pointer-events-none absolute inset-0 z-10 grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
             <div className="border-r border-border" />
             <div className="border-r border-border" />
@@ -63,7 +62,7 @@ export default function GetInTouch() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="group relative flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
-                  aria-label={`Follow me on ${name} (opens in a new tab)`}
+                  aria-label={`Follow me on ${name}`}
                 >
                   <div className="flex flex-col items-center transition-transform duration-300 group-hover:-translate-y-2 sm:group-hover:-translate-y-3">
                     <Logo className="size-8 sm:size-10" aria-hidden="true" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -61,17 +61,3 @@
   @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-border;
   @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-border;
 }
-
-/* Staggered entry animation */
-.social-grid-item {
-  opacity: 0;
-  transform: translateY(16px);
-  transition:
-    opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1) var(--delay, 0ms),
-    transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) var(--delay, 0ms);
-}
-
-.social-grid-item.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,17 +21,6 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
-
-  --animate-marquee: marquee-scroll 40s linear infinite;
-
-  @keyframes marquee-scroll {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(-50%);
-    }
-  }
 }
 
 :root {
@@ -71,4 +60,18 @@
   @apply relative;
   @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-border;
   @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-border;
+}
+
+/* Staggered entry animation */
+.social-grid-item {
+  opacity: 0;
+  transform: translateY(16px);
+  transition:
+    opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1) var(--delay, 0ms),
+    transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) var(--delay, 0ms);
+}
+
+.social-grid-item.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,6 +21,17 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  --animate-marquee: marquee-scroll 40s linear infinite;
+
+  @keyframes marquee-scroll {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-50%);
+    }
+  }
 }
 
 :root {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,4 +59,5 @@
 @utility line-y {
   @apply relative;
   @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-border;
+  @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-border;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,5 +59,4 @@
 @utility line-y {
   @apply relative;
   @apply before:absolute before:top-0 before:-left-[100vw] before:h-px before:w-[200vw] before:bg-border;
-  @apply after:absolute after:bottom-0 after:-left-[100vw] after:h-px after:w-[200vw] after:bg-border;
 }


### PR DESCRIPTION
This PR implements a horizontal infinite marquee for the 'Get in touch' section, inspired by the 'Follow Me' section on martingarrix.com. 

Key changes:
- Added `marquee-scroll` keyframes and an `animate-marquee` utility to `src/styles/globals.css`.
- Refactored `src/components/get-in-touch.tsx` to replace the static grid with an animated ticker.
- Applied bold uppercase styling and used a separator glyph (✦) between social links.
- Ensured the animation pauses on hover and remains accessible via a hidden semantic list for screen readers.

---
*PR created automatically by Jules for task [1958814725453256221](https://jules.google.com/task/1958814725453256221) started by @torn4dom4n*