### PR TITLE
Fix GitHub Pages 404 page rendering

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { copyFileSync } from "node:fs";
+import { resolve } from "node:path";
 import Icons from "unplugin-icons/vite";
 import { defineConfig } from "vite-plus";
 
@@ -78,6 +80,14 @@ export default defineConfig({
       compiler: "jsx",
       jsx: "react",
     }),
+    {
+      name: "copy-404",
+      apply: "build",
+      closeBundle() {
+        const distDir = resolve("dist");
+        copyFileSync(resolve(distDir, "index.html"), resolve(distDir, "404.html"));
+      },
+    },
   ],
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
Added a post-build plugin to vite.config.ts that copies dist/index.html to dist/404.html. This ensures that GitHub Pages correctly serves the SPA for all paths, allowing React Router to handle 404 logic and other client-side routes.

---
*PR created automatically by Jules for task [13850949439848409358](https://jules.google.com/task/13850949439848409358) started by @torn4dom4n*