### PR TITLE
Enable SPA mode and remove manual entry files

### DIFF
--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -1,4 +1,0 @@
-import { StartClient } from "@tanstack/react-start/client";
-import { hydrateRoot } from "react-dom/client";
-
-hydrateRoot(document, <StartClient />);

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,3 +1,0 @@
-import { createStartHandler, defaultRenderHandler } from "@tanstack/react-start/server";
-
-export default createStartHandler(defaultRenderHandler);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,4 @@
-import {
-  createRootRoute,
-  HeadContent,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 
 import { Footer } from "@/components/footer";
 import NotFound from "@/components/not-found";
@@ -81,7 +75,6 @@ function RootComponent() {
               </div>
             </div>
           </main>
-          <ScrollRestoration />
         </ThemeProvider>
         <Scripts />
       </body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
     tanstackStart({
       spa: {
         enabled: true,
+        prerender: { outputPath: "/index" },
       },
     }),
     tailwindcss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,9 +65,8 @@ export default defineConfig({
   base,
   plugins: [
     tanstackStart({
-      prerender: {
+      spa: {
         enabled: true,
-        autoSubfolderIndex: false,
       },
     }),
     tailwindcss(),


### PR DESCRIPTION
Enabled SPA mode in TanStack Start by updating `vite.config.ts` with `spa: { enabled: true }` and removing the `prerender` configuration. Removed `src/entry-client.tsx` and `src/entry-server.tsx` as they are now optional and automatically handled by the framework. Verified the changes via production build and visual verification with Playwright.

---
*PR created automatically by Jules for task [16872881771025506875](https://jules.google.com/task/16872881771025506875) started by @torn4dom4n*