### PR TITLE
Prevent Flash of Incorrect Theme (FOIT)

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -69,6 +69,28 @@ function RootComponent() {
   return (
     <html lang="en">
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem("vite-ui-theme") || "system";
+                  var root = document.documentElement;
+                  root.classList.remove("light", "dark");
+
+                  if (theme === "system") {
+                    var systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+                      ? "dark"
+                      : "light";
+                    root.classList.add(systemTheme);
+                  } else {
+                    root.classList.add(theme);
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
         <HeadContent />
         <script
           type="application/ld+json"


### PR DESCRIPTION
Added a blocking inline script to the <head> of the root route to apply the theme class before the initial paint, ensuring that users with dark mode enabled do not see a brief flash of light mode upon reloading the page.

---
*PR created automatically by Jules for task [16061320561993474101](https://jules.google.com/task/16061320561993474101) started by @torn4dom4n*