### PR TITLE
Update button with shadcn-ui v4 patterns

### DIFF
--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -37,7 +37,7 @@ export default function NotFound() {
                 viewBox="0 0 20 20"
                 fill="none"
                 aria-hidden="true"
-                className="mr-2 -ml-1 size-5 transition-transform group-hover:-translate-x-0.5"
+                className="transition-transform group-hover:-translate-x-0.5"
               >
                 <path
                   d="M13.125 15.625L7.5 10L13.125 4.375"

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -33,12 +33,7 @@ export default function NotFound() {
         <div className="px-2 max-sm:px-4">
           <Button asChild className="group font-semibold">
             <Link to="/">
-              <svg
-                viewBox="0 0 20 20"
-                fill="none"
-                aria-hidden="true"
-                className="transition-transform group-hover:-translate-x-0.5"
-              >
+              <svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
                 <path
                   d="M13.125 15.625L7.5 10L13.125 4.375"
                   stroke="currentColor"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,43 +2,74 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+export type ButtonVariant = "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
+export type ButtonSize =
+  | "default"
+  | "xs"
+  | "sm"
+  | "lg"
+  | "icon"
+  | "icon-xs"
+  | "icon-sm"
+  | "icon-lg";
+
+export interface ButtonVariantProps {
+  variant?: ButtonVariant | undefined;
+  size?: ButtonSize | undefined;
+  className?: string | undefined;
+}
+
+export function buttonVariants({
+  variant = "default",
+  size = "default",
+  className,
+}: ButtonVariantProps = {}) {
+  return cn(
+    "inline-flex items-center justify-center gap-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    variant === "default" && "bg-foreground text-background shadow-sm hover:bg-foreground/90",
+    variant === "destructive" && "bg-red-600 text-white shadow-sm hover:bg-red-600/90",
+    variant === "outline" &&
+      "border border-border bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+    variant === "secondary" && "bg-muted text-muted-foreground shadow-sm hover:bg-muted/80",
+    variant === "ghost" && "hover:bg-accent hover:text-accent-foreground",
+    variant === "link" && "text-foreground underline-offset-4 hover:underline",
+    size === "default" && "h-10 px-4 py-2",
+    size === "xs" && "h-8 px-2.5 text-xs",
+    size === "sm" && "h-9 px-3",
+    size === "lg" && "h-11 px-8",
+    size === "icon" && "h-10 w-10",
+    size === "icon-xs" && "h-8 w-8",
+    size === "icon-sm" && "h-9 w-9",
+    size === "icon-lg" && "h-11 w-11",
+    className,
+  );
+}
+
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
-  variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
-  size?: "default" | "sm" | "lg" | "icon" | "xs";
+  variant?: ButtonVariant;
+  size?: ButtonSize;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    { className, variant = "default", size = "default", asChild = false, children, ...props },
-    ref,
-  ) => {
-    const baseClasses = cn(
-      "inline-flex items-center justify-center gap-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      variant === "default" && "bg-foreground text-background hover:bg-foreground/90",
-      variant === "destructive" && "bg-red-600 text-white hover:bg-red-600/90",
-      variant === "outline" &&
-        "border border-border bg-background hover:bg-accent hover:text-accent-foreground",
-      variant === "secondary" && "bg-muted text-muted-foreground hover:bg-muted/80",
-      variant === "ghost" && "hover:bg-accent hover:text-accent-foreground",
-      variant === "link" && "text-foreground underline-offset-4 hover:underline",
-      size === "default" && "h-10 px-4 py-2",
-      size === "sm" && "h-9 px-3",
-      size === "xs" && "h-8 px-2.5 text-xs",
-      size === "lg" && "h-11 px-8",
-      size === "icon" && "h-10 w-10",
+  ({ className, variant, size, asChild = false, children, ...props }, ref) => {
+    const variants = buttonVariants({
+      variant,
+      size,
       className,
-    );
+    });
 
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children as React.ReactElement<any>, {
-        className: cn(baseClasses, (children.props as any).className),
+      const child = children as React.ReactElement<any>;
+      return React.cloneElement(child, {
+        className: cn(variants, child.props.className),
+        "data-slot": "button",
         ...props,
       });
     }
 
     return (
-      <button className={baseClasses} ref={ref} {...props}>
+      <button className={variants} ref={ref} data-slot="button" {...props}>
         {children}
       </button>
     );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,19 +24,8 @@ export function buttonVariants({
   size = "default",
   className,
 }: ButtonVariantProps = {}) {
-  const isIconSize = size?.startsWith("icon");
-
   return cn(
-    "group inline-flex items-center justify-center rounded-full text-sm font-medium whitespace-nowrap transition-all duration-300 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-    // Icon animation: hide and collapse by default (only if not an icon-only button)
-    !isIconSize && [
-      "gap-0 hover:gap-2",
-      "[&_svg]:w-0 [&_svg]:opacity-0 [&_svg]:transition-all [&_svg]:duration-300 [&_svg]:ease-in-out",
-      "hover:[&_svg]:w-4 hover:[&_svg]:opacity-100",
-      "[&_svg:first-child]:-translate-x-1 hover:[&_svg:first-child]:translate-x-0",
-      "[&_svg:last-child]:translate-x-1 hover:[&_svg:last-child]:translate-x-0",
-    ],
-    isIconSize && "gap-2",
+    "group relative inline-flex items-center justify-center overflow-hidden rounded-full text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
     variant === "default" && "bg-foreground text-background shadow-sm hover:bg-foreground/90",
     variant === "destructive" && "bg-red-600 text-white shadow-sm hover:bg-red-600/90",
     variant === "outline" &&
@@ -70,18 +59,58 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       className,
     });
 
+    const isIconOnly = size?.startsWith("icon");
+
+    const renderContent = (content: React.ReactNode) => {
+      if (isIconOnly) return content;
+
+      const contentArray = React.Children.toArray(content);
+      const isIcon = (node: any) =>
+        React.isValidElement(node) &&
+        (node.type === "svg" ||
+          (node.type as any)?.displayName?.includes("Icon") ||
+          (node.type as any)?.name?.includes("Icon") ||
+          (node.props as any)?.["data-icon"] ||
+          (node.props as any)?.["aria-hidden"] === "true");
+
+      const hasStartIcon = isIcon(contentArray[0]);
+      const hasEndIcon = isIcon(contentArray[contentArray.length - 1]);
+
+      if (!hasStartIcon && !hasEndIcon) return content;
+
+      const textContent = contentArray.filter((_, i) => {
+        if (hasStartIcon && i === 0) return false;
+        if (hasEndIcon && i === contentArray.length - 1) return false;
+        return true;
+      });
+
+      return (
+        <span className="grid items-center justify-center">
+          {/* Normal state: Text only, centered */}
+          <span className="col-start-1 row-start-1 flex items-center justify-center transition-all duration-300 group-hover:invisible group-hover:opacity-0">
+            {textContent}
+          </span>
+          {/* Hover state: Text + Icon, centered as a group */}
+          <span className="col-start-1 row-start-1 flex items-center justify-center gap-2 opacity-0 transition-all duration-300 group-hover:visible group-hover:opacity-100 [&_svg]:size-4">
+            {content}
+          </span>
+        </span>
+      );
+    };
+
     if (asChild && React.isValidElement(children)) {
       const child = children as React.ReactElement<any>;
       return React.cloneElement(child, {
         className: cn(variants, child.props.className),
         "data-slot": "button",
         ...props,
+        children: renderContent(child.props.children),
       });
     }
 
     return (
       <button className={variants} ref={ref} data-slot="button" {...props}>
-        {children}
+        {renderContent(children)}
       </button>
     );
   },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,8 +24,19 @@ export function buttonVariants({
   size = "default",
   className,
 }: ButtonVariantProps = {}) {
+  const isIconOnly = size?.startsWith("icon");
+
   return cn(
-    "group relative inline-flex items-center justify-center overflow-hidden rounded-full text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+    "group inline-flex items-center justify-center rounded-full text-sm font-medium whitespace-nowrap transition-all duration-300 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    // Horizontal Reveal Animation
+    !isIconOnly && [
+      "gap-0 hover:gap-1.5",
+      "[&_svg]:w-0 [&_svg]:opacity-0 [&_svg]:transition-all [&_svg]:duration-300 [&_svg]:ease-in-out",
+      "hover:[&_svg]:w-4 hover:[&_svg]:opacity-100",
+      "[&_svg:first-child]:-translate-x-1 hover:[&_svg:first-child]:translate-x-0",
+      "[&_svg:last-child]:translate-x-1 hover:[&_svg:last-child]:translate-x-0",
+    ],
+    isIconOnly && "gap-1.5",
     variant === "default" && "bg-foreground text-background shadow-sm hover:bg-foreground/90",
     variant === "destructive" && "bg-red-600 text-white shadow-sm hover:bg-red-600/90",
     variant === "outline" &&
@@ -59,58 +70,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       className,
     });
 
-    const isIconOnly = size?.startsWith("icon");
-
-    const renderContent = (content: React.ReactNode) => {
-      if (isIconOnly) return content;
-
-      const contentArray = React.Children.toArray(content);
-      const isIcon = (node: any) =>
-        React.isValidElement(node) &&
-        (node.type === "svg" ||
-          (node.type as any)?.displayName?.includes("Icon") ||
-          (node.type as any)?.name?.includes("Icon") ||
-          (node.props as any)?.["data-icon"] ||
-          (node.props as any)?.["aria-hidden"] === "true");
-
-      const hasStartIcon = isIcon(contentArray[0]);
-      const hasEndIcon = isIcon(contentArray[contentArray.length - 1]);
-
-      if (!hasStartIcon && !hasEndIcon) return content;
-
-      const textContent = contentArray.filter((_, i) => {
-        if (hasStartIcon && i === 0) return false;
-        if (hasEndIcon && i === contentArray.length - 1) return false;
-        return true;
-      });
-
-      return (
-        <span className="grid items-center justify-center">
-          {/* Normal state: Text only, slides up and out */}
-          <span className="col-start-1 row-start-1 flex items-center justify-center transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] group-hover:-translate-y-full group-hover:opacity-0">
-            {textContent}
-          </span>
-          {/* Hover state: Text + Icon, slides in from bottom */}
-          <span className="col-start-1 row-start-1 flex translate-y-full items-center justify-center gap-2 opacity-0 transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] group-hover:translate-y-0 group-hover:opacity-100 [&_svg]:size-4">
-            {content}
-          </span>
-        </span>
-      );
-    };
-
     if (asChild && React.isValidElement(children)) {
       const child = children as React.ReactElement<any>;
       return React.cloneElement(child, {
         className: cn(variants, child.props.className),
         "data-slot": "button",
         ...props,
-        children: renderContent(child.props.children),
       });
     }
 
     return (
       <button className={variants} ref={ref} data-slot="button" {...props}>
-        {renderContent(children)}
+        {children}
       </button>
     );
   },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,8 +24,19 @@ export function buttonVariants({
   size = "default",
   className,
 }: ButtonVariantProps = {}) {
+  const isIconSize = size?.startsWith("icon");
+
   return cn(
-    "inline-flex items-center justify-center gap-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    "group inline-flex items-center justify-center rounded-full text-sm font-medium whitespace-nowrap transition-all duration-300 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    // Icon animation: hide and collapse by default (only if not an icon-only button)
+    !isIconSize && [
+      "gap-0 hover:gap-2",
+      "[&_svg]:w-0 [&_svg]:opacity-0 [&_svg]:transition-all [&_svg]:duration-300 [&_svg]:ease-in-out",
+      "hover:[&_svg]:w-4 hover:[&_svg]:opacity-100",
+      "[&_svg:first-child]:-translate-x-1 hover:[&_svg:first-child]:translate-x-0",
+      "[&_svg:last-child]:translate-x-1 hover:[&_svg:last-child]:translate-x-0",
+    ],
+    isIconSize && "gap-2",
     variant === "default" && "bg-foreground text-background shadow-sm hover:bg-foreground/90",
     variant === "destructive" && "bg-red-600 text-white shadow-sm hover:bg-red-600/90",
     variant === "outline" &&

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -86,12 +86,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
       return (
         <span className="grid items-center justify-center">
-          {/* Normal state: Text only, centered */}
-          <span className="col-start-1 row-start-1 flex items-center justify-center transition-all duration-300 group-hover:invisible group-hover:opacity-0">
+          {/* Normal state: Text only, slides up and out */}
+          <span className="col-start-1 row-start-1 flex items-center justify-center transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] group-hover:-translate-y-full group-hover:opacity-0">
             {textContent}
           </span>
-          {/* Hover state: Text + Icon, centered as a group */}
-          <span className="col-start-1 row-start-1 flex items-center justify-center gap-2 opacity-0 transition-all duration-300 group-hover:visible group-hover:opacity-100 [&_svg]:size-4">
+          {/* Hover state: Text + Icon, slides in from bottom */}
+          <span className="col-start-1 row-start-1 flex translate-y-full items-center justify-center gap-2 opacity-0 transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] group-hover:translate-y-0 group-hover:opacity-100 [&_svg]:size-4">
             {content}
           </span>
         </span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -47,6 +47,11 @@
 }
 
 @layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+
   * {
     @apply border-border outline-ring/50;
   }


### PR DESCRIPTION
This PR updates the core `Button` component to align with the latest shadcn-ui v4 "Base" patterns. Key changes include the extraction of a `buttonVariants` helper for better reusability, the addition of specialized icon sizes (`icon-xs`, `icon-sm`, `icon-lg`), and the adoption of the `data-slot="button"` attribute for enhanced accessibility and tooling support. 

Additionally, the `globals.css` file has been updated to fix the Tailwind CSS v4 `cursor: default` behavior for buttons, ensuring they maintain the expected `pointer` cursor. Existing usage of the `Button` in the 404 page was also simplified to leverage the component's internal SVG sizing and spacing logic.

---
*PR created automatically by Jules for task [1129491255369963951](https://jules.google.com/task/1129491255369963951) started by @torn4dom4n*