### PR TITLE
Standardize SSG export to 'out/' directory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run build
         uses: area44/workflows/vite-plus@v4.4.0
         with:
-          path: 'dist/client'
+          path: 'out'
 
   deploy:
     needs: build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,8 @@ jobs:
         uses: area44/workflows/vite-plus@v4.4.0
         with:
           path: 'out'
+        env:
+          BUILD_COMMAND: pnpm build
 
   deploy:
     needs: build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-slim
+    env:
+      BUILD_COMMAND: pnpm build
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -21,8 +23,6 @@ jobs:
         uses: area44/workflows/vite-plus@v4.4.0
         with:
           path: 'out'
-        env:
-          BUILD_COMMAND: pnpm build
 
   deploy:
     needs: build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,14 +13,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-slim
-    env:
-      BUILD_COMMAND: pnpm build
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run build
-        uses: area44/workflows/vite-plus@v4.4.0
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'out'
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vinext dev",
-    "build": "vinext build && cp -r dist/client out && touch out/.nojekyll",
+    "build": "vinext build && rm -rf out && mv dist/client out && touch out/.nojekyll",
     "preview": "vinext start",
     "lint": "vp lint",
     "format": "vp fmt",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vinext dev",
-    "build": "vinext build",
+    "build": "vinext build && cp -r dist/client out && touch out/.nojekyll",
     "preview": "vinext start",
     "lint": "vp lint",
     "format": "vp fmt",

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "name": "@torn4dom4n/website",
   "framework": "vite",
-  "buildCommand": "vp build",
+  "buildCommand": "pnpm build",
   "outputDirectory": "out",
   "cleanUrls": true,
   "github": {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "name": "@torn4dom4n/website",
   "framework": "vite",
   "buildCommand": "vp build",
-  "outputDirectory": "dist/client",
+  "outputDirectory": "out",
   "cleanUrls": true,
   "github": {
     "autoJobCancelation": true


### PR DESCRIPTION
This change standardizes the Static Site Generation (SSG) output for the project. Although Vinext correctly pre-renders routes when 'output: export' is set, it defaults to a nested 'dist/client' structure and includes server artifacts. To align with standard deployment practices and simplify the GitHub Pages workflow, I've added a post-build step to consolidate the static site into a root 'out/' directory and include a '.nojekyll' file. GitHub Actions and Vercel configurations have been updated to use this new output path.

---
*PR created automatically by Jules for task [1183454079683622152](https://jules.google.com/task/1183454079683622152) started by @torn4dom4n*