### PR TITLE
fix: icon spacing in 404 button

### DIFF
--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -37,7 +37,7 @@ export default function NotFound() {
                 viewBox="0 0 20 20"
                 fill="none"
                 aria-hidden="true"
-                className="mr-2 -ml-1 size-5 transition-transform group-hover:-translate-x-0.5"
+                className="transition-transform group-hover:-translate-x-0.5"
               >
                 <path
                   d="M13.125 15.625L7.5 10L13.125 4.375"


### PR DESCRIPTION
Simplified the icon layout in the 404 page button by removing manual `mr-2`, `-ml-1`, and `size-5` classes. This allows the `Button` component's internal `gap-2` and `[&_svg]:size-4` utilities to handle the spacing and sizing consistently with the rest of the application.

---
*PR created automatically by Jules for task [1333094988136555332](https://jules.google.com/task/1333094988136555332) started by @torn4dom4n*