### PR TITLE
refactor: remove robots-txt-plugin and use static robots.txt

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_SITE_URL=https://torn4dom4n.github.io
+VITE_SITE_URL = http://localhost:5173

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_SITE_URL = http://localhost:5173
+VITE_SITE_URL=https://torn4dom4n.github.io

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: http://localhost:5173/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: http://localhost:5173/sitemap.xml
+Sitemap: https://torn4dom4n.github.io/sitemap.xml

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,4 @@
-export const SITE_URL =
-  (import.meta.env["VITE_SITE_URL"] as string) || "https://torn4dom4n.github.io";
+export const SITE_URL = (import.meta.env["VITE_SITE_URL"] as string) || "http://localhost:5173";
 export const SITE_NAME = "Long Nhat Nguyen";
 export const AUTHOR_NAME = "Long Nhat Nguyen";
 export const TWITTER_HANDLE = "@torn4dom4n";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
-export const SITE_URL = (import.meta.env["VITE_SITE_URL"] as string) || "http://localhost:5173";
+export const SITE_URL =
+  (import.meta.env["VITE_SITE_URL"] as string) || "https://torn4dom4n.github.io";
 export const SITE_NAME = "Long Nhat Nguyen";
 export const AUTHOR_NAME = "Long Nhat Nguyen";
 export const TWITTER_HANDLE = "@torn4dom4n";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
         autoSubfolderIndex: false,
       },
       sitemap: {
-        host: process.env.VITE_SITE_URL || "http://localhost:5173",
+        host: process.env.VITE_SITE_URL || "https://torn4dom4n.github.io",
       },
     }),
     tailwindcss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
         autoSubfolderIndex: false,
       },
       sitemap: {
-        host: process.env.VITE_SITE_URL || "https://torn4dom4n.github.io",
+        host: process.env.VITE_SITE_URL || "http://localhost:5173",
       },
     }),
     tailwindcss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,5 @@
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
 import Icons from "unplugin-icons/vite";
 import { defineConfig } from "vite-plus";
 
@@ -20,20 +18,6 @@ const ignorePatterns = [
   "**/.netlify",
   "**/*.gen.*",
 ];
-
-function robotsPlugin() {
-  return {
-    name: "robots-txt-plugin",
-    closeBundle: () => {
-      const siteUrl = process.env.VITE_SITE_URL || "http://localhost:5173";
-      const robots = `User-agent: *
-Allow: /
-
-Sitemap: ${siteUrl}/sitemap.xml`;
-      writeFileSync(join("dist", "client", "robots.txt"), robots);
-    },
-  };
-}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -94,7 +78,6 @@ export default defineConfig({
       compiler: "jsx",
       jsx: "react",
     }),
-    robotsPlugin(),
   ],
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
Removed the custom robots-txt-plugin from vite.config.ts and replaced it with a static robots.txt file in the public directory. This simplifies the build process and adheres to standard practices.

---
*PR created automatically by Jules for task [12744361837287494424](https://jules.google.com/task/12744361837287494424) started by @torn4dom4n*