### PR TITLE
🎨 Palette: Keyboard-Focus Accessibility and micro-UX Improvements

### DIFF
--- a/src/components/get-in-touch.tsx
+++ b/src/components/get-in-touch.tsx
@@ -67,12 +67,12 @@ export default function GetInTouch() {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group relative flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background sm:px-2 sm:py-4"
+                  className="group relative flex aspect-square size-full items-center justify-center text-foreground/80 transition-colors duration-300 hover:bg-foreground hover:text-background focus-visible:bg-foreground focus-visible:text-background focus-visible:outline-none sm:px-2 sm:py-4"
                   aria-label={`Follow me on ${name}`}
                 >
-                  <div className="flex flex-col items-center transition-transform duration-300 group-hover:-translate-y-2 sm:group-hover:-translate-y-3">
+                  <div className="flex flex-col items-center transition-transform duration-300 group-hover:-translate-y-2 group-focus-visible:-translate-y-2 sm:group-hover:-translate-y-3 sm:group-focus-visible:-translate-y-3">
                     <Logo className="size-8 sm:size-10" aria-hidden="true" />
-                    <span className="absolute top-full mt-1 text-[10px] font-bold tracking-widest uppercase opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:mt-2 sm:text-xs">
+                    <span className="absolute top-full mt-1 text-[10px] font-bold tracking-widest uppercase opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100 sm:mt-2 sm:text-xs">
                       {name}
                     </span>
                   </div>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -24,7 +24,7 @@ function ThemeToggleButton({
   return (
     <label
       title={title}
-      className={`relative flex cursor-pointer items-center justify-center rounded-full p-1 transition-all ${
+      className={`relative flex cursor-pointer items-center justify-center rounded-full p-1 transition-all has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring ${
         selected
           ? "shadow-elevation bg-background text-foreground"
           : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"

--- a/src/components/ui/spotify-card.tsx
+++ b/src/components/ui/spotify-card.tsx
@@ -71,10 +71,11 @@ export function SpotifyCard({ data, className }: SpotifyCardProps) {
       </div>
       <button
         onClick={data.audio ? handlePlayPause : undefined}
+        disabled={!data.audio}
         type="button"
         aria-label={isPlaying ? "Pause preview" : "Play preview"}
         className={cn(
-          "group relative z-1 w-full max-w-18.75 self-center",
+          "group relative z-1 w-full max-w-18.75 self-center rounded-lg transition-shadow focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
           data.audio && "cursor-pointer",
         )}
       >
@@ -85,7 +86,7 @@ export function SpotifyCard({ data, className }: SpotifyCardProps) {
           decoding="async"
           className={cn(
             "pointer-events-none relative z-1 min-h-18.75 w-full min-w-18.75 rounded-lg object-cover shadow-md transition-transform duration-300 ease-out select-none",
-            data.audio && "group-hover:-translate-x-0.5",
+            data.audio && "group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5",
             isPlaying && "-translate-x-0.5",
           )}
         />
@@ -95,7 +96,7 @@ export function SpotifyCard({ data, className }: SpotifyCardProps) {
               "absolute top-1/2 left-1/2 -z-1 size-[80%] -translate-y-1/2 transition-all duration-300",
               isPlaying
                 ? "translate-x-[-10%]"
-                : "translate-x-[-50%] group-hover:translate-x-[-10%]",
+                : "translate-x-[-50%] group-hover:translate-x-[-10%] group-focus-visible:translate-x-[-10%]",
             )}
           >
             <svg


### PR DESCRIPTION
Hello! As "Palette" 🎨 - your UX-focused agent, I have implemented a wonderful set of keyboard-accessibility and focus-visible micro-UX improvements to the website.

### 💡 What: The UX enhancement added
- **Spotify Now Playing Card**: Added proper `disabled` logic when audio previews are not present, alongside visual focus rings and `group-focus-visible` states so the cover art and vinyl disc shift effect triggers beautifully on keyboard focus.
- **Social Connect Grid**: Enhanced brand grid links with `focus-visible` background highlight, icon translation, and brand-name overlay text display to make navigating the socials page with a keyboard identical in fidelity to hovering.
- **Segmented Theme Control**: Wrapped the theme toggles with CSS `has-[:focus-visible]:ring-1` so users with screen readers and keyboard setups see a perfectly aligned, modern focus ring when tabbing through Light/Dark/System.

### 🎯 Why: The user problem it solves
Before, tabbing through these elements either had zero visual cue or lacked the high-fidelity delightful micro-interactions that mouse hover users get to experience. This change guarantees WCAG-compliant keyboard navigation clarity and visual delight for everyone.

### ♿ Accessibility
- Standard focus rings added via `focus-visible:ring-ring focus-visible:outline-none`.
- Interactive labels automatically fade and translate upward on focus.
- Interactive custom elements behave precisely the same under both mouse hover and tabbed keyboard focus.

---
*PR created automatically by Jules for task [9620817463230503869](https://jules.google.com/task/9620817463230503869) started by @torn4dom4n*