### PR TITLE
Update text selection matching style with shadcn-ui style

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -55,6 +55,10 @@
   body {
     @apply bg-background text-foreground antialiased;
   }
+
+  ::selection {
+    @apply bg-foreground text-background;
+  }
 }
 
 @utility line-y {


### PR DESCRIPTION
Updates the global browser text selection style to match the standard high-contrast, minimalist style of shadcn-ui using the existing `--foreground` and `--background` utility design tokens, without creating any new variables. Also ensures consistent custom selection styles across all components.

---
*PR created automatically by Jules for task [9839570084971835076](https://jules.google.com/task/9839570084971835076) started by @torn4dom4n*