### PR TITLE
feat(404): integrate Drawesome interactive canvas on 404 page

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-router": "^1.170.27",
     "@tanstack/react-start": "^1.168.44",
     "clsx": "^2.1.1",
+    "drawesome": "^0.1.1",
     "lucide-react": "^1.31.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      drawesome:
+        specifier: ^0.1.1
+        version: 0.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -1376,6 +1379,13 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  drawesome@0.1.1:
+    resolution: {integrity: sha512-HPFnbyyqZ9IrkS+ETAwcA6wZ4gZDgfrD4fSMcsRFvkDtuZ6a+svR6tPYM340ouAGAgcva2QuslqIX6FR6L4FcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
 
   electron-to-chromium@1.5.403:
     resolution: {integrity: sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==}
@@ -3115,6 +3125,11 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  drawesome@0.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   electron-to-chromium@1.5.403: {}
 

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,6 +1,8 @@
-import { Draw } from "drawesome";
-import { useEffect, useState } from "react";
+import { Draw, type DrawHandle } from "drawesome";
+import { Download } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import GridContainer from "@/components/ui/grid-container";
 import SectionHeader from "@/components/ui/section-header";
 
@@ -8,6 +10,7 @@ import SectionHeader from "@/components/ui/section-header";
 export default function NotFound() {
   const [isMounted, setIsMounted] = useState(false);
   const [isNarrow, setIsNarrow] = useState(false);
+  const drawRef = useRef<DrawHandle>(null);
 
   useEffect(() => {
     setIsMounted(true);
@@ -22,8 +25,16 @@ export default function NotFound() {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
+  const handleExportPng = () => {
+    void drawRef.current?.download("doodle", "png", 2);
+  };
+
+  const handleExportSvg = () => {
+    void drawRef.current?.download("doodle", "svg");
+  };
+
   return (
-    <div className="pt-16 pb-12 sm:pt-24">
+    <div className="pt-16 pb-16 sm:pt-24 sm:pb-20">
       {/* 404 Section Tag */}
       <GridContainer className="2xl:before:hidden 2xl:after:hidden">
         <SectionHeader className="text-foreground/80">404</SectionHeader>
@@ -38,25 +49,46 @@ export default function NotFound() {
 
       <div className="h-6 sm:h-10" />
 
-      {/* Error explanation paragraph */}
+      {/* Error explanation paragraph & export action buttons */}
       <GridContainer>
-        <div className="px-2 max-sm:px-4">
+        <div className="flex flex-col gap-4 px-2 max-sm:px-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="max-w-(--breakpoint-md) text-lg/7 text-muted-foreground">
             The page you are looking for doesn't exist or has been moved. Feel free to doodle below
             while you're here.
           </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportPng}
+              className="cursor-pointer font-medium"
+            >
+              <Download />
+              Export PNG
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportSvg}
+              className="cursor-pointer font-medium"
+            >
+              <Download />
+              Export SVG
+            </Button>
+          </div>
         </div>
       </GridContainer>
 
-      <div className="h-6 sm:h-10" />
+      <div className="h-8 sm:h-12" />
 
-      {/* Drawesome interactive canvas area */}
+      {/* Centered Drawesome interactive canvas area */}
       <GridContainer>
-        <div className="px-2 max-sm:px-4">
-          <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
+        <div className="px-2 py-4 max-sm:px-4 sm:py-6">
+          <div className="relative mx-auto h-[500px] w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-muted/20 p-2 shadow-sm sm:p-4">
             {isMounted &&
               (isNarrow ? (
                 <Draw
+                  ref={drawRef}
                   background="transparent"
                   theme="auto"
                   placement="left"
@@ -64,7 +96,7 @@ export default function NotFound() {
                   controls={{ undo: false, clear: false, opacity: false, custom: false }}
                 />
               ) : (
-                <Draw background="transparent" theme="auto" placement="bottom" />
+                <Draw ref={drawRef} background="transparent" theme="auto" placement="bottom" />
               ))}
           </div>
         </div>

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,4 +1,6 @@
 import { Link } from "@tanstack/react-router";
+import { Draw } from "drawesome";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import GridContainer from "@/components/ui/grid-container";
@@ -6,8 +8,14 @@ import SectionHeader from "@/components/ui/section-header";
 
 // Fallback error block for non-existent pages (404)
 export default function NotFound() {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   return (
-    <div className="pt-16 sm:pt-24">
+    <div className="pt-16 pb-12 sm:pt-24">
       {/* 404 Section Tag */}
       <GridContainer className="2xl:before:hidden 2xl:after:hidden">
         <SectionHeader className="text-foreground/80">404</SectionHeader>
@@ -22,39 +30,45 @@ export default function NotFound() {
 
       <div className="h-6 sm:h-10" />
 
-      {/* Error explanation paragraph */}
+      {/* Error explanation paragraph & back home button */}
       <GridContainer>
-        <div className="px-2 max-sm:px-4">
+        <div className="flex flex-col gap-4 px-2 max-sm:px-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="max-w-(--breakpoint-md) text-lg/7 text-muted-foreground">
-            The page you are looking for doesn't exist or has been moved.
+            The page you are looking for doesn't exist or has been moved. Feel free to doodle below
+            while you're here.
           </p>
+          <div>
+            <Button asChild className="group font-semibold">
+              <Link to="/">
+                <svg
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                  className="transition-transform group-hover:-translate-x-0.5"
+                >
+                  <path
+                    d="M13.125 15.625L7.5 10L13.125 4.375"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                Back to home
+              </Link>
+            </Button>
+          </div>
         </div>
       </GridContainer>
 
       <div className="h-6 sm:h-10" />
 
-      {/* Back to home redirect link button */}
+      {/* Drawesome interactive canvas area */}
       <GridContainer>
         <div className="px-2 max-sm:px-4">
-          <Button asChild className="group font-semibold">
-            <Link to="/">
-              <svg
-                viewBox="0 0 20 20"
-                fill="none"
-                aria-hidden="true"
-                className="transition-transform group-hover:-translate-x-0.5"
-              >
-                <path
-                  d="M13.125 15.625L7.5 10L13.125 4.375"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-              Back to home
-            </Link>
-          </Button>
+          <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
+            {isMounted && <Draw background="transparent" theme="auto" />}
+          </div>
         </div>
       </GridContainer>
     </div>

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -38,18 +38,16 @@ export default function NotFound() {
         </div>
       </GridContainer>
 
-      {/* Drawesome interactive canvas area (hidden on mobile, visible on desktop/tablet) */}
-      <div className="hidden md:block">
-        <div className="h-6 sm:h-10" />
+      <div className="h-6 sm:h-10" />
 
-        <GridContainer>
-          <div className="px-2 max-sm:px-4">
-            <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
-              {isMounted && <Draw background="transparent" theme="auto" />}
-            </div>
+      {/* Drawesome interactive canvas area */}
+      <GridContainer>
+        <div className="px-2 max-sm:px-4">
+          <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
+            {isMounted && <Draw background="transparent" theme="auto" />}
           </div>
-        </GridContainer>
-      </div>
+        </div>
+      </GridContainer>
     </div>
   );
 }

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,8 +1,6 @@
-import { Link } from "@tanstack/react-router";
 import { Draw } from "drawesome";
 import { useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import GridContainer from "@/components/ui/grid-container";
 import SectionHeader from "@/components/ui/section-header";
 
@@ -30,47 +28,28 @@ export default function NotFound() {
 
       <div className="h-6 sm:h-10" />
 
-      {/* Error explanation paragraph & back home button */}
+      {/* Error explanation paragraph */}
       <GridContainer>
-        <div className="flex flex-col gap-4 px-2 max-sm:px-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="px-2 max-sm:px-4">
           <p className="max-w-(--breakpoint-md) text-lg/7 text-muted-foreground">
             The page you are looking for doesn't exist or has been moved. Feel free to doodle below
             while you're here.
           </p>
-          <div>
-            <Button asChild className="group font-semibold">
-              <Link to="/">
-                <svg
-                  viewBox="0 0 20 20"
-                  fill="none"
-                  aria-hidden="true"
-                  className="transition-transform group-hover:-translate-x-0.5"
-                >
-                  <path
-                    d="M13.125 15.625L7.5 10L13.125 4.375"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                Back to home
-              </Link>
-            </Button>
-          </div>
         </div>
       </GridContainer>
 
-      <div className="h-6 sm:h-10" />
+      {/* Drawesome interactive canvas area (hidden on mobile, visible on desktop/tablet) */}
+      <div className="hidden md:block">
+        <div className="h-6 sm:h-10" />
 
-      {/* Drawesome interactive canvas area */}
-      <GridContainer>
-        <div className="px-2 max-sm:px-4">
-          <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
-            {isMounted && <Draw background="transparent" theme="auto" />}
+        <GridContainer>
+          <div className="px-2 max-sm:px-4">
+            <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
+              {isMounted && <Draw background="transparent" theme="auto" />}
+            </div>
           </div>
-        </div>
-      </GridContainer>
+        </GridContainer>
+      </div>
     </div>
   );
 }

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -7,9 +7,19 @@ import SectionHeader from "@/components/ui/section-header";
 // Fallback error block for non-existent pages (404)
 export default function NotFound() {
   const [isMounted, setIsMounted] = useState(false);
+  const [isNarrow, setIsNarrow] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
+
+    const mql = window.matchMedia("(max-width: 679px)");
+    const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsNarrow(e.matches);
+    };
+
+    onChange(mql);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
   }, []);
 
   return (
@@ -44,7 +54,18 @@ export default function NotFound() {
       <GridContainer>
         <div className="px-2 max-sm:px-4">
           <div className="relative h-[480px] w-full overflow-hidden rounded-xl border border-border bg-muted/20">
-            {isMounted && <Draw background="transparent" theme="auto" />}
+            {isMounted &&
+              (isNarrow ? (
+                <Draw
+                  background="transparent"
+                  theme="auto"
+                  placement="left"
+                  tools={["pencil", "pen", "marker", "highlighter", "brush"]}
+                  controls={{ undo: false, clear: false, opacity: false, custom: false }}
+                />
+              ) : (
+                <Draw background="transparent" theme="auto" placement="bottom" />
+              ))}
           </div>
         </div>
       </GridContainer>

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -29,10 +29,6 @@ export default function NotFound() {
     void drawRef.current?.download("doodle", "png", 2);
   };
 
-  const handleExportSvg = () => {
-    void drawRef.current?.download("doodle", "svg");
-  };
-
   return (
     <div className="pt-16 pb-16 sm:pt-24 sm:pb-20">
       {/* 404 Section Tag */}
@@ -49,33 +45,13 @@ export default function NotFound() {
 
       <div className="h-6 sm:h-10" />
 
-      {/* Error explanation paragraph & export action buttons */}
+      {/* Error explanation paragraph */}
       <GridContainer>
-        <div className="flex flex-col gap-4 px-2 max-sm:px-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="px-2 max-sm:px-4">
           <p className="max-w-(--breakpoint-md) text-lg/7 text-muted-foreground">
             The page you are looking for doesn't exist or has been moved. Feel free to doodle below
             while you're here.
           </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleExportPng}
-              className="cursor-pointer font-medium"
-            >
-              <Download />
-              Export PNG
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleExportSvg}
-              className="cursor-pointer font-medium"
-            >
-              <Download />
-              Export SVG
-            </Button>
-          </div>
         </div>
       </GridContainer>
 
@@ -92,12 +68,32 @@ export default function NotFound() {
                   background="transparent"
                   theme="auto"
                   placement="left"
+                  drawWhenMinimized
                   tools={["pencil", "pen", "marker", "highlighter", "brush"]}
                   controls={{ undo: false, clear: false, opacity: false, custom: false }}
                 />
               ) : (
-                <Draw ref={drawRef} background="transparent" theme="auto" placement="bottom" />
+                <Draw
+                  ref={drawRef}
+                  background="transparent"
+                  theme="auto"
+                  placement="bottom"
+                  drawWhenMinimized
+                />
               ))}
+          </div>
+
+          {/* Export PNG action button below canvas */}
+          <div className="mt-4 flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportPng}
+              className="cursor-pointer font-medium"
+            >
+              <Download />
+              Export PNG
+            </Button>
           </div>
         </div>
       </GridContainer>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "@fontsource-variable/geist";
 @import "@fontsource-variable/geist-mono";
+@import "drawesome/styles.css";
 
 @theme inline {
   --font-sans: "Geist Variable", "Geist fallback", "Geist", sans-serif;


### PR DESCRIPTION
Integrates the Drawesome drawing toolbar and canvas into the 404 page (`src/components/not-found.tsx`) with `@import "drawesome/styles.css";` in `src/styles/globals.css`.

---
*PR created automatically by Jules for task [560469942746208681](https://jules.google.com/task/560469942746208681) started by @torn4dom4n*